### PR TITLE
Fix generation on MacOS

### DIFF
--- a/src/Types.thrift
+++ b/src/Types.thrift
@@ -1481,8 +1481,8 @@ struct Resource {
  *  is treated as "read-only" for clients; the server will ignore changes
  *  to this field from an external client.
  *  </dd>
- *
- * <dt>reminderOrder</dt>
+ */
+/** <dt>reminderOrder</dt>
  * <dd>The set of notes with this parameter set are considered
  * "reminders" and are to be treated specially by clients to give them
  * higher UI prominence within a notebook.  The value is used to sort


### PR DESCRIPTION
One of the comments is too large for out-of-the-box `brew` installed thrift on MacOS.

### Steps to reproduce

1. Install brew on MacOS
2. Install thrift using brew
    `brew install thrift`
3. Generate Source
    `thrift -gen go src/Types.thrift`

This outputs simply

```
token too large, exceeds YYLMAX
```

### Solution

Apparently to fix this issue in thrift, requires recompiling thrift manually, and modifying some of the macro defaults in the source code. 

Or we can just make sure no tokens are too large when parsing the thrift files. Tokens would be things like identifiers, strings, or comments. An entire comment is taken as one token, so it can easily ignored by the compiler. This is common in parser design.

The only illegal token in evernote-thrift is this one comment in `Types.thrift`. Easily modified.

### Environment Details

MacOS El Capitan
brew v1.1.1 (latest)


### Notes

I'm not sure of the contribution process for this repo. @akhaku @mgsxx @sethhitch


### Prologue

Now I can generate the client for Golang!

```
type NoteStore interface { //Service:  NoteStore
        //<p>
        //The NoteStore service is used by EDAM clients to exchange information
        //about the collection of notes in an account. This is primarily used for
        //synchronization, but could also be used by a "thin" client without a full
        //local cache.
        //</p><p>
```
